### PR TITLE
Upgrade to RN 0.40.0

### DIFF
--- a/ios/Discourse.xcodeproj/project.pbxproj
+++ b/ios/Discourse.xcodeproj/project.pbxproj
@@ -23,7 +23,6 @@
 		226098D21D655CC9001A0518 /* libRCTPushNotification.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 226098D11D655C00001A0518 /* libRCTPushNotification.a */; };
 		22728C5A1D7E44F100FB7227 /* RNBackgroundJob.m in Sources */ = {isa = PBXBuildFile; fileRef = 22728C591D7E44F100FB7227 /* RNBackgroundJob.m */; };
 		2275E8C11D891D2900327641 /* RNBackgroundFetch.m in Sources */ = {isa = PBXBuildFile; fileRef = 2275E8C01D891D2900327641 /* RNBackgroundFetch.m */; };
-		229A44281E13920000C4297B /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 229A44251E13919A00C4297B /* libRCTAnimation.a */; };
 		29A5744DA0BC49DF86270373 /* libSafariViewManager.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F996349405C34010996EE336 /* libSafariViewManager.a */; };
 		2DC1D89CEDF74F62B515F966 /* libRNECC.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BE631481BC54AEDB434F50A /* libRNECC.a */; };
 		5A9B9D17F302472BBBD88186 /* libRNDeviceInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2084424E16BE4B72A25D79DC /* libRNDeviceInfo.a */; };
@@ -101,6 +100,62 @@
 			remoteGlobalIDString = 83CBBA2E1A601D0E00E9B192;
 			remoteInfo = React;
 		};
+		219030CD1E55423C00861699 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3D3C059A1DE3340900C268FA;
+			remoteInfo = yoga;
+		};
+		219030CF1E55423C00861699 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3D3C06751DE3340C00C268FA;
+			remoteInfo = "yoga-tvOS";
+		};
+		219030D11E55423C00861699 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3D3CD9251DE5FBEC00167DC4;
+			remoteInfo = cxxreact;
+		};
+		219030D31E55423C00861699 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3D3CD9321DE5FBEE00167DC4;
+			remoteInfo = "cxxreact-tvOS";
+		};
+		219030D51E55423C00861699 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3D3CD90B1DE5FBD600167DC4;
+			remoteInfo = jschelpers;
+		};
+		219030D71E55423C00861699 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3D3CD9181DE5FBD800167DC4;
+			remoteInfo = "jschelpers-tvOS";
+		};
+		219030E31E55425A00861699 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 219030DE1E55425A00861699 /* RCTAnimation.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 134814201AA4EA6300B7C361;
+			remoteInfo = RCTAnimation;
+		};
+		219030E51E55425A00861699 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 219030DE1E55425A00861699 /* RCTAnimation.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 2D2A28201D9B03D100D4039D;
+			remoteInfo = "RCTAnimation-tvOS";
+		};
 		2219FD941D75354100A906CE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 4B79D987F06E411DA4302BA3 /* SafariViewManager.xcodeproj */;
@@ -128,20 +183,6 @@
 			proxyType = 2;
 			remoteGlobalIDString = 2DD0EFE61DA8533A00B0C975;
 			remoteInfo = "RCTPushNotification-tvOS";
-		};
-		229A44241E13919A00C4297B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 229A441F1E13919A00C4297B /* RCTAnimation.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = RCTAnimation;
-		};
-		229A44261E13919A00C4297B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 229A441F1E13919A00C4297B /* RCTAnimation.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 2D2A28201D9B03D100D4039D;
-			remoteInfo = "RCTAnimation-tvOS";
 		};
 		22A2D1B31D7640D100CD5F05 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -271,13 +312,13 @@
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = Discourse/main.m; sourceTree = "<group>"; };
 		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
 		2084424E16BE4B72A25D79DC /* libRNDeviceInfo.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNDeviceInfo.a; sourceTree = "<group>"; };
+		219030DE1E55425A00861699 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
 		226098CB1D6465BA001A0518 /* Discourse.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = Discourse.entitlements; path = Discourse/Discourse.entitlements; sourceTree = "<group>"; };
 		226098CC1D655C00001A0518 /* RCTPushNotification.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTPushNotification.xcodeproj; path = "../node_modules/react-native/Libraries/PushNotificationIOS/RCTPushNotification.xcodeproj"; sourceTree = "<group>"; };
 		22728C591D7E44F100FB7227 /* RNBackgroundJob.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNBackgroundJob.m; sourceTree = "<group>"; };
 		22728C6D1D7E450D00FB7227 /* RNBackgroundJob.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNBackgroundJob.h; sourceTree = "<group>"; };
 		2275E8AD1D891D1F00327641 /* RNBackgroundFetch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNBackgroundFetch.h; sourceTree = "<group>"; };
 		2275E8C01D891D2900327641 /* RNBackgroundFetch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNBackgroundFetch.m; sourceTree = "<group>"; };
-		229A441F1E13919A00C4297B /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "/Users/sam/Source/DiscourseMobile/node_modules/react-native-vector-icons/../react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<absolute>"; };
 		3CB836B0207247C4B1101787 /* RNDeviceInfo.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNDeviceInfo.xcodeproj; path = "../node_modules/react-native-device-info/RNDeviceInfo.xcodeproj"; sourceTree = "<group>"; };
 		4A01B54512B844D58735C60D /* libRNVectorIcons.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNVectorIcons.a; sourceTree = "<group>"; };
 		4B79D987F06E411DA4302BA3 /* SafariViewManager.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = SafariViewManager.xcodeproj; path = "../node_modules/react-native-safari-view/SafariViewManager.xcodeproj"; sourceTree = "<group>"; };
@@ -306,7 +347,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				229A44281E13920000C4297B /* libRCTAnimation.a in Frameworks */,
 				226098D21D655CC9001A0518 /* libRCTPushNotification.a in Frameworks */,
 				146834051AC3E58100842450 /* libReact.a in Frameworks */,
 				00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */,
@@ -430,7 +470,22 @@
 			isa = PBXGroup;
 			children = (
 				146834041AC3E56700842450 /* libReact.a */,
-				22E06E571DC9AA2F00EDED37 /* libReact-tvOS.a */,
+				22E06E571DC9AA2F00EDED37 /* libReact.a */,
+				219030CE1E55423C00861699 /* libyoga.a */,
+				219030D01E55423C00861699 /* libyoga.a */,
+				219030D21E55423C00861699 /* libcxxreact.a */,
+				219030D41E55423C00861699 /* libcxxreact.a */,
+				219030D61E55423C00861699 /* libjschelpers.a */,
+				219030D81E55423C00861699 /* libjschelpers.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		219030DF1E55425A00861699 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				219030E41E55425A00861699 /* libRCTAnimation.a */,
+				219030E61E55425A00861699 /* libRCTAnimation-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -456,15 +511,6 @@
 			children = (
 				226098D11D655C00001A0518 /* libRCTPushNotification.a */,
 				229A44071E138B7D00C4297B /* libRCTPushNotification-tvOS.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		229A44201E13919A00C4297B /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				229A44251E13919A00C4297B /* libRCTAnimation.a */,
-				229A44271E13919A00C4297B /* libRCTAnimation-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -498,7 +544,7 @@
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
-				229A441F1E13919A00C4297B /* RCTAnimation.xcodeproj */,
+				219030DE1E55425A00861699 /* RCTAnimation.xcodeproj */,
 				226098CC1D655C00001A0518 /* RCTPushNotification.xcodeproj */,
 				146833FF1AC3E56700842450 /* React.xcodeproj */,
 				00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */,
@@ -664,8 +710,8 @@
 					ProjectRef = 00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */;
 				},
 				{
-					ProductGroup = 229A44201E13919A00C4297B /* Products */;
-					ProjectRef = 229A441F1E13919A00C4297B /* RCTAnimation.xcodeproj */;
+					ProductGroup = 219030DF1E55425A00861699 /* Products */;
+					ProjectRef = 219030DE1E55425A00861699 /* RCTAnimation.xcodeproj */;
 				},
 				{
 					ProductGroup = 00C302B61ABCB90400DB3ED1 /* Products */;
@@ -797,6 +843,62 @@
 			remoteRef = 146834031AC3E56700842450 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		219030CE1E55423C00861699 /* libyoga.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libyoga.a;
+			remoteRef = 219030CD1E55423C00861699 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		219030D01E55423C00861699 /* libyoga.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libyoga.a;
+			remoteRef = 219030CF1E55423C00861699 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		219030D21E55423C00861699 /* libcxxreact.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libcxxreact.a;
+			remoteRef = 219030D11E55423C00861699 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		219030D41E55423C00861699 /* libcxxreact.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libcxxreact.a;
+			remoteRef = 219030D31E55423C00861699 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		219030D61E55423C00861699 /* libjschelpers.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libjschelpers.a;
+			remoteRef = 219030D51E55423C00861699 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		219030D81E55423C00861699 /* libjschelpers.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libjschelpers.a;
+			remoteRef = 219030D71E55423C00861699 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		219030E41E55425A00861699 /* libRCTAnimation.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRCTAnimation.a;
+			remoteRef = 219030E31E55425A00861699 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		219030E61E55425A00861699 /* libRCTAnimation-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libRCTAnimation-tvOS.a";
+			remoteRef = 219030E51E55425A00861699 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		2219FD951D75354100A906CE /* libSafariViewManager.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -823,20 +925,6 @@
 			fileType = archive.ar;
 			path = "libRCTPushNotification-tvOS.a";
 			remoteRef = 229A44061E138B7D00C4297B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		229A44251E13919A00C4297B /* libRCTAnimation.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRCTAnimation.a;
-			remoteRef = 229A44241E13919A00C4297B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		229A44271E13919A00C4297B /* libRCTAnimation-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libRCTAnimation-tvOS.a";
-			remoteRef = 229A44261E13919A00C4297B /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		22A2D1B41D7640D100CD5F05 /* libRNKeyPair.a */ = {
@@ -888,10 +976,10 @@
 			remoteRef = 22E06E521DC9AA2F00EDED37 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		22E06E571DC9AA2F00EDED37 /* libReact-tvOS.a */ = {
+		22E06E571DC9AA2F00EDED37 /* libReact.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = "libReact-tvOS.a";
+			path = libReact.a;
 			remoteRef = 22E06E561DC9AA2F00EDED37 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};

--- a/ios/Discourse.xcodeproj/xcshareddata/xcschemes/Discourse-tvOS.xcscheme
+++ b/ios/Discourse.xcodeproj/xcshareddata/xcschemes/Discourse-tvOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "2D2A28121D9B038B00D4039D"
-               BuildableName = "libReact-tvOS.a"
+               BuildableName = "libReact.a"
                BlueprintName = "React-tvOS"
                ReferencedContainer = "container:../node_modules/react-native/React/React.xcodeproj">
             </BuildableReference>

--- a/ios/Discourse.xcodeproj/xcshareddata/xcschemes/Discourse.xcscheme
+++ b/ios/Discourse.xcodeproj/xcshareddata/xcschemes/Discourse.xcscheme
@@ -3,9 +3,23 @@
    LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "83CBBA2D1A601D0E00E9B192"
+               BuildableName = "libReact.a"
+               BlueprintName = "React"
+               ReferencedContainer = "container:../node_modules/react-native/React/React.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"

--- a/ios/Discourse/AppDelegate.m
+++ b/ios/Discourse/AppDelegate.m
@@ -9,12 +9,12 @@
 
 #import "AppDelegate.h"
 
-#import "RCTBundleURLProvider.h"
-#import "RCTRootView.h"
-#import "RCTLinkingManager.h"
-#import "RCTPushNotificationManager.h"
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
+#import <React/RCTPushNotificationManager.h>
 #import "RNBackgroundFetch.h"
-#import "RCTLog.h"
+#import <React/RCTLog.h>
 #import "Orientation.h"
 
 @implementation AppDelegate

--- a/ios/RNBackgroundFetch.h
+++ b/ios/RNBackgroundFetch.h
@@ -1,4 +1,4 @@
-#import "RCTEventEmitter.h"
+#import <React/RCTEventEmitter.h>
 
 @interface RNBackgroundFetch : RCTEventEmitter
 

--- a/ios/RNBackgroundFetch.m
+++ b/ios/RNBackgroundFetch.m
@@ -1,10 +1,10 @@
 #import "RNBackgroundFetch.h"
 #import <UIKit/UIKit.h>
 
-#import "RCTBridge.h"
-#import "RCTEventDispatcher.h"
-#import "RCTUtils.h"
-#import "RCTLog.h"
+#import <React/RCTBridge.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTUtils.h>
+#import <React/RCTLog.h>
 
 NSString *const RNBackgroundFetchGotNotification = @"RNBackgroundFetchGotNotification";
 

--- a/ios/RNBackgroundJob.h
+++ b/ios/RNBackgroundJob.h
@@ -12,7 +12,7 @@
 
 #endif /* RNBackgroundJob_h */
 
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface RNBackgroundJob : NSObject <RCTBridgeModule>
 

--- a/ios/RNBackgroundJob.m
+++ b/ios/RNBackgroundJob.m
@@ -1,10 +1,10 @@
 #import "RNBackgroundJob.h"
 #import <UIKit/UIKit.h>
 
-#import "RCTBridge.h"
-#import "RCTEventDispatcher.h"
-#import "RCTUtils.h"
-#import "RCTLog.h"
+#import <React/RCTBridge.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTUtils.h>
+#import <React/RCTLog.h>
 
 
 @implementation RNBackgroundJob {

--- a/package.json
+++ b/package.json
@@ -12,16 +12,16 @@
     "lodash": "^4.15.0",
     "moment": "^2.14.1",
     "react": "15.4.2",
-    "react-native": "=0.39.2",
-    "react-native-device-info": "^0.9.4",
-    "react-native-ecc": "^1.2.2",
+    "react-native": "0.40.0",
+    "react-native-device-info": "0.10.0",
+    "react-native-ecc": "1.4.0",
     "react-native-key-pair": "git+https://github.com/samsaffron/react-native-key-pair.git",
     "react-native-orientation": "git+https://github.com/yamill/react-native-orientation",
     "react-native-progress": "^3.0.1",
-    "react-native-safari-view": "git+https://github.com/samsaffron/react-native-safari-view.git",
-    "react-native-sortable-listview": "git+https://github.com/samsaffron/react-native-sortable-listview.git",
+    "react-native-safari-view": "2.0.0",
+    "react-native-sortable-listview": "0.1.1",
     "react-native-swipeout": "git+https://github.com/dancormier/react-native-swipeout.git",
-    "react-native-vector-icons": "^2.1.0"
+    "react-native-vector-icons": "4.0.0"
   },
   "devDependencies": {
     "@kadira/react-native-storybook": "^2.0.0",


### PR DESCRIPTION
Updates react-native as requested per https://discuss.reactjs.org/t/having-a-hell-of-a-time-upgrading-from-react-native-39-to-40/6331/2 and https://github.com/facebook/react-native/issues/12265#issuecomment-278284946 

It mainly updates the header imports in most files, adds an extra step to the build process, and updates out of date packages. 

It should run just with a `yarn` and `react-native run-ios` 

Let me know if it doesn't (you might just need to relink RCTAnimation, if so).