### PR TITLE
Enabling split view on iPads.

### DIFF
--- a/ios/Discourse/AppDelegate.m
+++ b/ios/Discourse/AppDelegate.m
@@ -142,7 +142,11 @@
 }
 
 - (UIInterfaceOrientationMask)application:(UIApplication *)application supportedInterfaceOrientationsForWindow:(UIWindow *)window {
-  return [Orientation getOrientation];
+  if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+    return UIInterfaceOrientationMaskAll;
+  } else {
+    return [Orientation getOrientation];
+  }
 }
 
 @end


### PR DESCRIPTION
Orientation mask needs to equal `.all` in order to support split view on iPads.

![simulator screen shot - ipad air 2 - 2018-11-08 at 16 05 47](https://user-images.githubusercontent.com/8276230/48207430-e86b7980-e370-11e8-8450-38b81b5310fc.png)
