### PR TITLE
Actually update Rubyzip dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ GEM
       multipart-post (~> 2.0.0)
       plist (>= 3.1.0, < 4.0.0)
       public_suffix (~> 2.0.0)
-      rubyzip (>= 1.3.0, < 2.0.0)
+      rubyzip (>= 1.2.2, < 2.0.0)
       security (= 0.1.3)
       simctl (~> 1.6.3)
       slack-notifier (>= 2.0.0, < 3.0.0)
@@ -116,7 +116,7 @@ GEM
       uber (< 0.2.0)
     retriable (3.1.2)
     rouge (2.0.7)
-    rubyzip (1.2.3)
+    rubyzip (1.3.0)
     security (0.1.3)
     signet (0.11.0)
       addressable (~> 2.3)
@@ -160,4 +160,4 @@ DEPENDENCIES
   fastlane-plugin-versioning
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
A redo of fa55f72, fixes the issue with `bundle install`:

```
Fetching fastlane 2.128.0
Downloading fastlane-2.128.0 revealed dependencies not in the API or the lockfile (rubyzip (>= 1.2.2, < 2.0.0)).
Either installing with `--full-index` or running `bundle update fastlane` should fix the problem.
```