### PR TITLE
DEV: Remove invalid options

### DIFF
--- a/js/screens/HomeScreen.js
+++ b/js/screens/HomeScreen.js
@@ -304,8 +304,7 @@ class HomeScreen extends React.Component {
     });
     return (
       <SafeAreaView
-        style={[styles.container, {backgroundColor: theme.background}]}
-        forceInset={{top: 'never', bottom: 'always'}}>
+        style={[styles.container, {backgroundColor: theme.background}]}>
         <Components.NavigationBar
           leftButtonIconRotated={this.state.displayTermBar ? true : false}
           anim={this.state.anim}

--- a/js/screens/HomeScreenComponents/NavigationBar.js
+++ b/js/screens/HomeScreenComponents/NavigationBar.js
@@ -50,9 +50,7 @@ class NavigationBar extends React.Component {
   render() {
     const theme = this.context;
     return (
-      <View
-        style={[styles.container, {backgroundColor: theme.background}]}
-        forceInset={{top: 'always', bottom: 'never'}}>
+      <View style={[styles.container, {backgroundColor: theme.background}]}>
         <ProgressBar progress={this.props.progress} />
         <View style={styles.leftContainer}>
           <TouchableHighlight

--- a/js/screens/NotificationsScreen.js
+++ b/js/screens/NotificationsScreen.js
@@ -92,9 +92,7 @@ class NotificationsScreen extends React.Component {
     }
 
     return (
-      <SafeAreaView
-        style={{flex: 1, backgroundColor: theme.background}}
-        forceInset={{top: 'never', bottom: 'always'}}>
+      <SafeAreaView style={{flex: 1, backgroundColor: theme.background}}>
         <Components.NavigationBar
           onDidPressRightButton={() => this._onDidPressRightButton()}
           onDidPressLeftButton={() => this._onDidPressLeftButton()}

--- a/js/screens/SettingsScreen.js
+++ b/js/screens/SettingsScreen.js
@@ -37,9 +37,7 @@ class SettingsScreen extends React.Component {
   render() {
     const theme = this.context;
     return (
-      <SafeAreaView
-        style={{flex: 1, backgroundColor: theme.background}}
-        forceInset={{top: 'never', bottom: 'always'}}>
+      <SafeAreaView style={{flex: 1, backgroundColor: theme.background}}>
         <Components.NavigationBar
           onDidPressRightButton={() => this._onDidPressRightButton()}
           progress={this.state.progress}


### PR DESCRIPTION
SafeAreaView does not have a forceInset option. I think it's a holdover from a time the app used react-navigation?