### PR TITLE
FIX: Notifications screen issues

### DIFF
--- a/js/screens/NotificationsScreen.js
+++ b/js/screens/NotificationsScreen.js
@@ -82,12 +82,12 @@ class NotificationsScreen extends React.Component {
 
     if (this.state.renderPlaceholderOnly) {
       return (
-        <View style={{flex: 1, backgroundColor: theme.grayBackground}}>
+        <SafeAreaView style={{flex: 1, backgroundColor: theme.background}}>
           <Components.NavigationBar onDidPressRightButton={() => {}} />
           <View style={{height: 50, marginTop: 0, paddingTop: 0}}>
             {this._renderListHeader()}
           </View>
-        </View>
+        </SafeAreaView>
       );
     }
 


### PR DESCRIPTION
The placeholder scrolled into view way too high (SafeAreaView fixes that) and had a background of a diffrent color that was immediately replaced with the correct one.