### PR TITLE
UX: Have site list take up all available vertical space

### DIFF
--- a/js/screens/HomeScreen.js
+++ b/js/screens/HomeScreen.js
@@ -252,6 +252,7 @@ class HomeScreen extends React.Component {
     } else {
       return (
         <DraggableFlatList
+          style={styles.sitesList}
           activationDistance={20}
           data={this.state.data}
           renderItem={item => this._renderItem(item)}
@@ -345,6 +346,9 @@ const styles = StyleSheet.create({
     flex: 1,
     marginTop: -TERM_BAR_HEIGHT,
     paddingBottom: 40,
+  },
+  sitesList: {
+    height: '100%',
   },
 });
 

--- a/js/site_manager.js
+++ b/js/site_manager.js
@@ -259,9 +259,13 @@ class SiteManager {
   }
 
   _throttledRefreshSites() {
-    console.log('refreshing ' + this.sites.length + ' sites');
-
     this.lastRefresh = new Date();
+    console.log(
+      'refreshing ' +
+        this.sites.length +
+        ' sites at ' +
+        this.lastRefresh.toJSON(),
+    );
     AsyncStorage.setItem('@Discourse.lastRefresh', this.lastRefresh.toJSON());
 
     let sites = this.sites.slice(0);


### PR DESCRIPTION
Fixes a small UI bug where the list of sites would be cut off when refreshing via the pull down gesture.