### PR TITLE
DEV: Use appstoreconnect key for testflight

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,6 +26,7 @@ lane :bootstrap do
   `git clone #{KEYS_REPOSITORY} keys`
 
   `openssl enc -aes-256-cbc -d -in keys/secrets.enc > keys/secrets.json -md md5`
+  `openssl enc -aes-256-cbc -d -in keys/appstoreconnect-key.enc > keys/appstoreconnect-key.json -md md5`
 
   File.open("google-play-api-secret.json","w") do |f|
     f.write(secrets["google-play-api-secret"].to_json)
@@ -155,12 +156,14 @@ platform :ios do
       force: true,
       type: "appstore",
       git_url: KEYS_REPOSITORY,
+      api_key_path: "fastlane/keys/appstoreconnect-key.json",
       app_identifier: ["org.discourse.DiscourseApp", "org.discourse.DiscourseApp.ShareExtension"]
     )
     match(
       force: true,
       type: "adhoc",
       git_url: KEYS_REPOSITORY,
+      api_key_path: "fastlane/keys/appstoreconnect-key.json",
       app_identifier: ["org.discourse.DiscourseApp", "org.discourse.DiscourseApp.ShareExtension"]
     )
     # match(force: true, type: "development", git_url: KEYS_REPOSITORY)
@@ -181,7 +184,7 @@ platform :ios do
       workspace: "./ios/#{PROJECT_NAME}.xcworkspace"
     )
 
-    upload_to_testflight(skip_waiting_for_build_processing: true)
+    pilot(skip_waiting_for_build_processing: true, api_key_path: "fastlane/keys/appstoreconnect-key.json")
   end
 
   desc "Install on connected device"

--- a/ios/Discourse.xcodeproj/project.pbxproj
+++ b/ios/Discourse.xcodeproj/project.pbxproj
@@ -481,7 +481,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 408;
+				CURRENT_PROJECT_VERSION = 410;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 6T3LU73T8S;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 6T3LU73T8S;
@@ -526,7 +526,7 @@
 				CODE_SIGN_ENTITLEMENTS = Discourse/Discourse.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 408;
+				CURRENT_PROJECT_VERSION = 410;
 				DEVELOPMENT_TEAM = 6T3LU73T8S;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 6T3LU73T8S;
 				ENABLE_BITCODE = NO;

--- a/ios/Discourse/Info.plist
+++ b/ios/Discourse/Info.plist
@@ -37,7 +37,7 @@
 		<dict/>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>408</string>
+	<string>410</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/ios/ShareExtension/Info.plist
+++ b/ios/ShareExtension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.8.9</string>
 	<key>CFBundleVersion</key>
-	<string>408</string>
+	<string>410</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>


### PR DESCRIPTION
Streamlines the process of uploading to testflight by using a key (instead of the usual authentication + 2FA).