### PR TITLE
A couple of fixes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,7 +2,7 @@ fastlane_require "base64"
 fastlane_require "fileutils"
 fastlane_require "json"
 
-IOS_APP_VERSION = "1.8.9"
+IOS_APP_VERSION = "1.8.10"
 ANDROID_APP_VERSION = "1.8.9"
 PROJECT_NAME = "Discourse"
 IOS_TEAM_ID = "6T3LU73T8S"

--- a/ios/Discourse.xcodeproj/project.pbxproj
+++ b/ios/Discourse.xcodeproj/project.pbxproj
@@ -481,7 +481,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 410;
+				CURRENT_PROJECT_VERSION = 412;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 6T3LU73T8S;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 6T3LU73T8S;
@@ -526,7 +526,7 @@
 				CODE_SIGN_ENTITLEMENTS = Discourse/Discourse.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 410;
+				CURRENT_PROJECT_VERSION = 412;
 				DEVELOPMENT_TEAM = 6T3LU73T8S;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 6T3LU73T8S;
 				ENABLE_BITCODE = NO;

--- a/ios/Discourse.xcodeproj/project.pbxproj
+++ b/ios/Discourse.xcodeproj/project.pbxproj
@@ -481,7 +481,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 412;
+				CURRENT_PROJECT_VERSION = 414;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 6T3LU73T8S;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 6T3LU73T8S;
@@ -499,7 +499,7 @@
 					"$(inherited)",
 					"\"$(SRCROOT)/Discourse\"/**",
 				);
-				MARKETING_VERSION = 1.8.4;
+				MARKETING_VERSION = 1.8.10;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -526,7 +526,7 @@
 				CODE_SIGN_ENTITLEMENTS = Discourse/Discourse.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 412;
+				CURRENT_PROJECT_VERSION = 414;
 				DEVELOPMENT_TEAM = 6T3LU73T8S;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 6T3LU73T8S;
 				ENABLE_BITCODE = NO;
@@ -543,7 +543,7 @@
 					"$(inherited)",
 					"\"$(SRCROOT)/Discourse\"/**",
 				);
-				MARKETING_VERSION = 1.8.4;
+				MARKETING_VERSION = 1.8.10;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -553,7 +553,7 @@
 				PRODUCT_NAME = Discourse;
 				PROVISIONING_PROFILE = "8a5dde79-abbd-4707-a921-2b4412ef65ad";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore org.discourse.DiscourseApp";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore org.discourse.DiscourseApp";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AdHoc org.discourse.DiscourseApp";
 				SWIFT_OBJC_BRIDGING_HEADER = "Discourse-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -695,7 +695,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.discourse.DiscourseApp.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc org.discourse.DiscourseApp.ShareExtension";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore org.discourse.DiscourseApp.ShareExtension";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AdHoc org.discourse.DiscourseApp.ShareExtension";
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -729,7 +729,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.discourse.DiscourseApp.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc org.discourse.DiscourseApp.ShareExtension";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore org.discourse.DiscourseApp.ShareExtension";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AdHoc org.discourse.DiscourseApp.ShareExtension";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;

--- a/ios/Discourse.xcodeproj/xcshareddata/xcschemes/Discourse.xcscheme
+++ b/ios/Discourse.xcodeproj/xcshareddata/xcschemes/Discourse.xcscheme
@@ -42,8 +42,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ios/Discourse/Info.plist
+++ b/ios/Discourse/Info.plist
@@ -37,7 +37,7 @@
 		<dict/>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>410</string>
+	<string>412</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>
@@ -58,6 +58,8 @@
 			</dict>
 		</array>
 	</dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>org.jitsi.meet</string>

--- a/ios/Discourse/Info.plist
+++ b/ios/Discourse/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.9</string>
+	<string>1.8.10</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -37,7 +37,7 @@
 		<dict/>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>412</string>
+	<string>414</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -345,7 +345,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - react-native-segmented-control (2.2.2):
     - React-Core
-  - react-native-webview (11.26.1):
+  - react-native-webview (12.0.2):
     - React-Core
   - React-perflogger (0.71.7)
   - React-RCTActionSheet (0.71.7):
@@ -727,7 +727,7 @@ SPEC CHECKSUMS:
   react-native-safari-web-auth: b6642abaa8084a8e5addba1cba4521fd30b95b64
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   react-native-segmented-control: 65df6cd0619b780b3843d574a72d4c7cec396097
-  react-native-webview: 9f111dfbcfc826084d6c507f569e5e03342ee1c1
+  react-native-webview: 203b6a1c7507737f777c91d7e10c30e7e67c1a17
   React-perflogger: 2d505bbe298e3b7bacdd9e542b15535be07220f6
   React-RCTActionSheet: 0e96e4560bd733c9b37efbf68f5b1a47615892fb
   React-RCTAnimation: fd138e26f120371c87e406745a27535e2c8a04ef

--- a/ios/ShareExtension/Info.plist
+++ b/ios/ShareExtension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.9</string>
+	<string>1.8.10</string>
 	<key>CFBundleVersion</key>
-	<string>412</string>
+	<string>414</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/ios/ShareExtension/Info.plist
+++ b/ios/ShareExtension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.8.9</string>
 	<key>CFBundleVersion</key>
-	<string>410</string>
+	<string>412</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/js/screens/WebViewScreen.js
+++ b/js/screens/WebViewScreen.js
@@ -276,7 +276,7 @@ class WebViewScreen extends React.Component {
 
   _sendAppStateChange(appState) {
     const appStateChange = `
-      window.dispatchEvent(new CustomEvent("AppStateChange", { newAppState: "${appState}" }));
+      window.dispatchEvent(new CustomEvent("AppStateChange", { detail: { newAppState: "${appState}" } }));
       true;
     `;
 

--- a/js/screens/WebViewScreen.js
+++ b/js/screens/WebViewScreen.js
@@ -162,6 +162,7 @@ class WebViewScreen extends React.Component {
           <WebView
             style={{
               marginTop: -1, // hacky fix to a 1px overflow just above header
+              backgroundColor: this.state.headerBg,
             }}
             ref={ref => (this.webview = ref)}
             source={{uri: this.state.webviewUrl}}

--- a/js/screens/WebViewScreen.js
+++ b/js/screens/WebViewScreen.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import {
   Animated,
+  AppState,
   View,
   Linking,
   Keyboard,
@@ -54,6 +55,10 @@ class WebViewScreen extends React.Component {
       this.safariViewVisible = false;
     });
 
+    this._handleAppStateChange = nextAppState => {
+      this._sendAppStateChange(nextAppState);
+    };
+
     this.state = {
       progress: 0,
       scrollDirection: '',
@@ -85,6 +90,11 @@ class WebViewScreen extends React.Component {
     this.keyboardWillHide = Keyboard.addListener(
       'keyboardDidHide',
       this._onKeyboardShow.bind(this),
+    );
+
+    this.appStateSubscription = AppState.addEventListener(
+      'change',
+      this._handleAppStateChange,
     );
   }
 
@@ -261,6 +271,16 @@ class WebViewScreen extends React.Component {
     this.keyboardWillShow?.remove();
     this.keyboardWillHide?.remove();
     this.siteManager.refreshSites();
+    this.appStateSubscription?.remove();
+  }
+
+  _sendAppStateChange(appState) {
+    const appStateChange = `
+      window.dispatchEvent(new CustomEvent("AppStateChange", { newAppState: "${appState}" }));
+      true;
+    `;
+
+    this.webview.injectJavaScript(appStateChange);
   }
 
   _onKeyboardShow() {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-native-svg": "^13.7.0",
     "react-native-swipe-list-view": "^3.2.9",
     "react-native-vector-icons": "^9.2.0",
-    "react-native-webview": "^11.23.0"
+    "react-native-webview": "^12.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/patches/react-native-siri-shortcut+3.2.2.patch
+++ b/patches/react-native-siri-shortcut+3.2.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native-siri-shortcut/ios/RNSSAddToSiriButtonViewManager.m b/node_modules/react-native-siri-shortcut/ios/RNSSAddToSiriButtonViewManager.m
-index 4705319..566fca1 100644
+index 4705319..df21980 100644
 --- a/node_modules/react-native-siri-shortcut/ios/RNSSAddToSiriButtonViewManager.m
 +++ b/node_modules/react-native-siri-shortcut/ios/RNSSAddToSiriButtonViewManager.m
 @@ -42,7 +42,7 @@ + (BOOL)requiresMainQueueSetup
@@ -7,7 +7,7 @@ index 4705319..566fca1 100644
  - (NSDictionary *)constantsToExport
  {
 -    INUIAddVoiceShortcutButton *button = [INUIAddVoiceShortcutButton new];
-+    INUIAddVoiceShortcutButton *button = [INUIAddVoiceShortcutButton alloc];
++    INUIAddVoiceShortcutButton *button = [[INUIAddVoiceShortcutButton alloc] initWithStyle:INUIAddVoiceShortcutButtonStyleAutomatic];
      button.translatesAutoresizingMaskIntoConstraints = NO;
      [button layoutIfNeeded];
  

--- a/patches/react-native-webview+12.0.2.patch
+++ b/patches/react-native-webview+12.0.2.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/react-native-webview/apple/RNCWebViewImpl.m b/node_modules/react-native-webview/apple/RNCWebViewImpl.m
+index c6d18bb..065723b 100644
+--- a/node_modules/react-native-webview/apple/RNCWebViewImpl.m
++++ b/node_modules/react-native-webview/apple/RNCWebViewImpl.m
+@@ -440,6 +440,18 @@ - (void)didMoveToWindow
+     [_webView addObserver:self forKeyPath:@"estimatedProgress" options:NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew context:nil];
+     _webView.allowsBackForwardNavigationGestures = _allowsBackForwardNavigationGestures;
+ 
++    // We have to do both the #if check and the @available check. The first gates compilation when compiling on older
++    // versions of Xcode (14.2 and lower, to be specific). The @available() checks ensure we're _running_ on a supported
++    // OS.
++    #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130300 || \
++        __IPHONE_OS_VERSION_MAX_ALLOWED >= 160400 || \
++        __TV_OS_VERSION_MAX_ALLOWED >= 160400
++        // https://webkit.org/blog/13936/enabling-the-inspection-of-web-content-in-apps/
++        if (@available(macos 13.3, ios 16.4, tvOS 16.4, *)) {
++            _webView.inspectable = YES;
++        }
++    #endif
++
+     _webView.customUserAgent = _userAgent;
+ 
+ #if !TARGET_OS_OSX

--- a/yarn.lock
+++ b/yarn.lock
@@ -6894,10 +6894,10 @@ react-native-vector-icons@^9.2.0:
     prop-types "^15.7.2"
     yargs "^16.1.1"
 
-react-native-webview@^11.23.0:
-  version "11.26.1"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.26.1.tgz#658c09ed5162dc170b361e48c2dd26c9712879da"
-  integrity sha512-hC7BkxOpf+z0UKhxFSFTPAM4shQzYmZHoELa6/8a/MspcjEP7ukYKpuSUTLDywQditT8yI9idfcKvfZDKQExGw==
+react-native-webview@^12.0.2:
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-12.0.2.tgz#6f75bc74f75a7585fb06743ffc20c267048512df"
+  integrity sha512-vEnFOgVIYaUAQb437BOZdwTteUv3dkXkYOajalUkMDHNz91Zb35HaG6L49uUSFp4qYw46y/U3licKS1BOISDrg==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
- better background color support for dark mode site overscrolling
- allow inspection in iOS/macOS
- add custom events (might be used by core to better show an offline indicator)

This last change is done using a patch from https://github.com/react-native-webview/react-native-webview/pull/2933, because react-native-webview doesn't yet support this. 