### PR TITLE
DEV: Trust the `wix/brew` tap so `applesimutils` installs in CI

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Install macOS dependencies
         run: |
           brew tap wix/brew
+          brew trust wix/brew
           brew install applesimutils
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
@@ -77,6 +78,7 @@ jobs:
       - name: Install macOS dependencies
         run: |
           brew tap wix/brew
+          brew trust wix/brew
           brew install applesimutils
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
Previously, the `ios-tests` workflow failed at `brew install applesimutils` because Homebrew now refuses to load formulae from the untrusted third-party `wix/brew` tap; `main` has been red on `ios-tests` for this reason, independent of any PR's contents.

This change runs `brew trust wix/brew` before installing, restoring CI's ability to install Detox's `applesimutils` on the macOS runner.